### PR TITLE
fix(config) ignore raw option from join if ascii

### DIFF
--- a/lib/resty/jq.lua
+++ b/lib/resty/jq.lua
@@ -143,6 +143,11 @@ local function check_filter_options(options)
     end
   end
 
+  -- join_output implies raw_output
+  if options.join_output then
+    options.raw_output = true
+  end
+
   -- jq ignores raw output in ascii mode
   if options.ascii_output and options.raw_output then
     options.raw_output = false
@@ -218,9 +223,7 @@ function jq:filter(data, options)
     if kind == lib.JV_KIND_INVALID then
       break
 
-    elseif kind == lib.JV_KIND_STRING
-      and (options.raw_output or options.join_output) then
-
+    elseif kind == lib.JV_KIND_STRING and options.raw_output then
       i = i + 1
       buf[i] = ffi.string(lib.jv_string_value(jv_next))
 

--- a/spec/01-unit_spec.lua
+++ b/spec/01-unit_spec.lua
@@ -175,6 +175,15 @@ describe("jq ffi", function()
       assert.same("\"bar\\u00e9\"\n", res)
     end)
 
+    it("ascii_output && join_output, implied raw is ignored", function()
+      jq:compile(".foo")
+
+      local res, err = jq:filter([[{"foo": "baré"}]], { ascii_output = true, join_output = true })
+      assert.is_nil(err)
+      assert.truthy(res)
+      assert.same("\"bar\\u00e9\"", res)
+    end)
+
     it("sort_keys", function()
       jq:compile(".")
 


### PR DESCRIPTION
join_output implies raw_output, but ascii_output should ignore the
raw-ness (keeping the joined-ness).
