### PR TITLE
chore(*) bump version to 0.1.0

### DIFF
--- a/lib/resty/jq.lua
+++ b/lib/resty/jq.lua
@@ -77,7 +77,7 @@ local DEFAULT_FILTER_OPTIONS = {
 
 
 local jq = {
-  _VERSION = "0.1",
+  _VERSION = "0.1.0",
 }
 
 jq.__index = jq

--- a/lua-resty-jq-0.1.0-0.rockspec
+++ b/lua-resty-jq-0.1.0-0.rockspec
@@ -1,9 +1,9 @@
 package = "lua-resty-jq"
-version = "0.0.2-0"
+version = "0.1.0-0"
 
 source = {
   url = "git://github.com/bungle/lua-resty-jq",
-  tag = "0.0.2"
+  tag = "0.1.0"
 }
 
 description = {


### PR DESCRIPTION
I went with `0.1.0` as I noticed the `_VERSION` was previously out of sync with the release tag.
