### PR TITLE
feat(filter) add table_output and reusable buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,34 @@ this option, you can force jq to produce pure ASCII output with every non-ASCII
 character replaced with the equivalent escape sequence. Default is `false`.
 * `sort_keys`: Output the fields of each object with the keys in sorted order.
   Default is `false`.
+* `table_output`: Returns a sequence-like table of encoded results instead of
+    concatenating them into a single string. Default is `false`.
 
+Additionally, `filter()` takes a table as an optional 3rd argument. When
+supplied, this table will be used to store results instead of creating a new
+table for each call to `filter()`:
+
+```lua
+local buf = {}
+local res, err = jq:filter(data, nil, buf)
+for _, elem in ipairs(buf) do
+  -- ...
+end
+```
+
+Doing so implies `options.table_output = true`, so this option must be
+explicitly set to `false` in order to receive a string result:
+
+```lua
+local buf = {}
+local res, err = jq:filter(data, { table_output = false }, buf)
+print(res)
+```
+
+**NOTE:** `filter()` adds a trailing `nil` to the table such that the length
+operator (`#buf`) and `ipairs(buf)` return accurate results after execution, but
+it does _not_ clear the table. Callers must clear the table themselves if
+desired.
 
 ## See Also
 


### PR DESCRIPTION
## table output

The premise for this change is to give users more control in handling a variable number of items in the output stream.

### before

```lua
jq:compile('.[]')

local res, err = jq:filter('[ "a", "b", { "c": 1 } ]')

-- must split lines to handle jsonl output
local results = {}
res:gsub("([^\n]+)", function(elem)
  table.insert(results, elem)
end)
```

### after


```lua
jq:compile('.[]')

local results, err = jq:filter('[ "a", "b", { "c": 1 } ]', { table_output = true })
```

## reusable buffer

When adding `table_output`, it seemed natural to also provide a means of reusing the internal buffer table that `:filter()` uses to keep results, so I also added this feature:

```lua
jq:compile('.[]')

local buf = {}
local res, err = jq:filter('[ "a", "b", { "c": 1 } ]', nil, buf)

-- supplying this 3rd argument implies `table_output = true`
assert(buf == res)
```

## etc

Initially I tried accomplishing this by refactoring the context setup and loop from `:filter()` such that the caller could control iteration themselves:

```lua
local ok, err = jq:start(data)
repeat
  local res, err = jq:next()
until res == nil or err ~= nil
```

In addition to supporting the `table_output` use case without requiring more cruft added to `options`, this would enable new patterns such as lazy filter execution/consumption and early-exit.

...but it's also slower than keeping the looping internal and makes the code less simple in order to guard against invalid usage/reentrancy things, so I abandoned this approach.